### PR TITLE
fix DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,29 @@
-'use strict';
+"use strict";
 
-function CleanTerminalPlugin(options = {}) {
-  const { message } = options;
+class CleanTerminalPlugin {
+  constructor(options = {}) {
+    this.message = options.message;
+  }
 
-  this.message = message;
-}
-
-CleanTerminalPlugin.prototype.apply = function(compiler) {
-  compiler.plugin('emit', (_, done) => {
-    if (process.env.NODE_ENV !== 'production') {
-      const clear = '\x1B[2J\x1B[3J\x1B[H';
-      const output = this.message ? clear + this.message + '\n\n' : clear;
-
-      process.stdout.write(output);
+  apply(compiler) {
+    if (compiler.hooks) {
+      compiler.hooks.afterCompile.tap("CleanTerminalPlugin", () => {
+        if (process.env.NODE_ENV !== "production") this.clearConsole();
+      });
+    } else {
+      // backwards compatible version of compiler.hooks
+      compiler.plugin("emit", (_, done) => {
+        if (process.env.NODE_ENV !== "production") this.clearConsole();
+        done();
+      });
     }
+  }
 
-    done();
-  });
-};
+  clearConsole() {
+    const clear = "\x1B[2J\x1B[3J\x1B[H";
+    const output = this.message ? clear + this.message + "\n\n" : clear;
+    process.stdout.write(output);
+  }
+}
 
 module.exports = CleanTerminalPlugin;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/danillouz/clean-terminal-webpack-plugin#readme",
   "peerDependencies": {
-    "webpack": "^3.0.0"
+    "webpack": "^3.0.0 || ^4.0.0"
   }
 }


### PR DESCRIPTION
this PR updates plugin tapable to be compatable with webpack v4 (`compiler.hooks`) and falls back onto the previous method (`compiler.plugin`) if using an older version of webpack