### PR TITLE
Fix bug for undefined-compiler in older webpack configs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# IntelliJ, Webstorm, etc
+.idea

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ class CleanTerminalPlugin {
     // Backwards compatible version of compiler.hooks
     if (!compiler.hooks) {
       compiler.plugin('emit', (_, done) => {
-        if (this.shouldClearConsole()) {
+        if (this.shouldClearConsole(compiler)) {
           this.clearConsole();
         }
 

--- a/index.js
+++ b/index.js
@@ -6,12 +6,13 @@ class CleanTerminalPlugin {
 
     this.message = message;
     this.onlyInWatchMode = onlyInWatchMode;
-    this.doClearConsole = false;
   }
 
   apply(compiler) {
-    // Depending on the API available, we either use compiler hooks
-    // or compiler events (compiler events are supported for backwards compatibility)
+    /*
+     * Depending on the API available, we either use compiler hooks
+     * or compiler events (compiler events are supported for backwards compatibility)
+     */
     if (compiler.hooks) {
       this.useCompilerHooks(compiler);
     } else {
@@ -21,24 +22,29 @@ class CleanTerminalPlugin {
 
   shouldClearConsole(compiler) {
     if (this.onlyInWatchMode) {
-      return !!compiler.watchMode;
+      return Boolean(compiler.watchMode);
     }
 
-    const isNodeEnvProduction = process.env.NODE_ENV == 'production';
-    const isOptionsModeProduction = process.env.mode && process.env.options.mode == 'production';
+    const isNodeEnvProduction = process.env.NODE_ENV === 'production';
+    const isOptionsModeProduction =
+      process.env.mode && process.env.options.mode === 'production';
 
     return !isNodeEnvProduction && !isOptionsModeProduction;
   }
 
   useCompilerHooks(compiler) {
     compiler.hooks.afterCompile.tap('CleanTerminalPlugin', () => {
-      if (this.shouldClearConsole(compiler)) this.clearConsole();
+      if (this.shouldClearConsole(compiler)) {
+        this.clearConsole();
+      }
     });
   }
 
   useCompilerEvents(compiler) {
     compiler.plugin('emit', (_, done) => {
-      if (this.shouldClearConsole(compiler)) this.clearConsole();
+      if (this.shouldClearConsole(compiler)) {
+        this.clearConsole();
+      }
       done();
     });
   }

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ class CleanTerminalPlugin {
 
     const isNodeEnvProduction = process.env.NODE_ENV === 'production';
     const isOptionsModeProduction =
-      process.env.mode && process.env.options.mode === 'production';
+      compiler.options && compiler.options.mode === 'production';
 
     return !isNodeEnvProduction && !isOptionsModeProduction;
   }

--- a/index.js
+++ b/index.js
@@ -26,8 +26,9 @@ class CleanTerminalPlugin {
     }
 
     const isNodeEnvProduction = process.env.NODE_ENV === 'production';
-    const isOptionsModeProduction =
-      compiler.options && compiler.options.mode === 'production';
+    const isOptionsModeProduction = Boolean(
+      compiler.options && compiler.options.mode === 'production'
+    );
 
     return !isNodeEnvProduction && !isOptionsModeProduction;
   }


### PR DESCRIPTION
I was having an issue where the plugin would not run and actually break the webpack build. As it turned out, a missing argument was the cause. I added it and rewrote some of the code since it seemed hard to grasp the concepts (for me peronally). Feel free to ignore the rewrite if you don't agree :) 