### PR TITLE
Add skipFirstRun option to skip console clean on first run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The plugin accepts an `options` Object:
 | ----------------- | ------- | -------- | ----------- | ------------------------------------------------- |
 | `message`         | String  | no       | `undefined` | Message to be printed                             |
 | `onlyInWatchMode` | Boolean | no       | `true`      | Only clear the screen if webpack is in watch mode |
+| `skipFirstRun`    | Boolean | no       | `false`     | Don't clear the screen on first webpack run       |
 
 ## Example
 

--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@
 
 class CleanTerminalPlugin {
   constructor(options = {}) {
-    const { message, onlyInWatchMode = true } = options;
+    const { message, onlyInWatchMode = true, skipFirstRun = false } = options;
 
     this.message = message;
     this.onlyInWatchMode = onlyInWatchMode;
+    this.skipFirstRun = skipFirstRun;
+    this.firstRun = true;
   }
 
   apply(compiler) {
@@ -21,6 +23,14 @@ class CleanTerminalPlugin {
   }
 
   shouldClearConsole(compiler) {
+    if (this.firstRun) {
+      this.firstRun = false;
+
+      if (this.skipFirstRun) {
+        return false;
+      }
+    }
+
     if (this.onlyInWatchMode) {
       return Boolean(compiler.watchMode);
     }


### PR DESCRIPTION
In monorepo setup, we may want to start webpack watch on multiple packages. Using this option, we can avoid cleaning the console on first build while all the packages run their initial build. The console will be cleaned on subsequent incremental build.